### PR TITLE
Remo help patch 1

### DIFF
--- a/dissertation.tex
+++ b/dissertation.tex
@@ -102,6 +102,12 @@
 
 \counterwithout{footnote}{chapter} %disable this if you want your footnotes to reset their counter for each chapter
 
+% the inlinetitle below will be used on the graduate college signature page if you uncomment it. 
+% This is useful if your completetitle uses a linebreak or other command that would break an inline use of that title. 
+% If you leave this commented it will do nothing. Uncomment and give it a value to activate. The change will be visible on page 2.
+
+%\inlinetitle{}
+
 \begin{document}
 
 % tocdepth defines how many layers of sections/subsections are displayed in your table of content. The hierarchy works like this:

--- a/uathesis.cls
+++ b/uathesis.cls
@@ -14,7 +14,7 @@
 %% Terry Hurford	2005
 %% Curtis S. Cooper	2007
 %% David A. Minton 2009
-%%
+%% Remo Nitschke 2023 (Linguistics)
 %%
 %% Todo:
 %% Currently footskip is zero.  This should be looked into.
@@ -457,6 +457,12 @@
 \newcommand{\CompleteTitle}{#1}
 }
 
+% inline title: We use this in case the complete title features a linebreak or something similar that we don't want in the Committee page
+
+\newcommand{\inlinetitle}[1]{%
+\newcommand{\Inlinetitle}{#1}
+}
+
 \newcommand{\fullname}[1]{%
 \newcommand{\FullName}{#1}
 }
@@ -576,7 +582,7 @@ THE UNIVERSITY OF ARIZONA
 
 \chapter*{THE UNIVERSITY OF ARIZONA\\GRADUATE COLLEGE}
 
-As members of the Dissertation Committee, we certify that we have read the \MakeLowercase{\ThesisType} prepared by \FullName, titled \CompleteTitle~and recommend that it be accepted as fulfilling the \MakeLowercase{\ThesisType} requirement for the Degree of \DegreeName. % NICK EDITED THIS LINE
+As members of the Dissertation Committee, we certify that we have read the \MakeLowercase{\ThesisType} prepared by \FullName, titled \emph{\ifthenelse{\isundefined{\Inlinetitle}}{\CompleteTitle}{\Inlinetitle}}~and recommend that it be accepted as fulfilling the \MakeLowercase{\ThesisType} requirement for the Degree of \DegreeName. % NICK EDITED THIS LINE
 
 % Before the final oral defense you must obtain the Approval Pages
 % from the Degree Certification Office. Original signatures are


### PR DESCRIPTION
adds the \inlinetitle option allowing a separate representation of the title for the inline use on the signature page